### PR TITLE
Docker Compose for Adding VPN

### DIFF
--- a/docker-composevpnsample.yml
+++ b/docker-composevpnsample.yml
@@ -1,0 +1,38 @@
+version: "3.3"
+
+services:
+  gluetun:
+    image: qmcgaw/gluetun
+    cap_add:
+      - NET_ADMIN
+    environment:
+    #Go Here For Adding VPN Environment Variables https://github.com/qdm12/gluetun
+      - VPN_SERVICE_PROVIDER=PROVIDER
+      - OPENVPN_USER=USERNAME
+      - OPENVPN_PASSWORD=PASSWORD
+      - SERVER_COUNTRIES=COUNTRY
+    ports:
+      - 127.0.0.1:6800:6800
+      - 127.0.0.1:8080:8080
+
+  downloader:
+    build: downloader
+    environment:
+      - RPCPORT=6800
+      - RPCSECRET=TEST123
+      - TORSERVNUM=50
+    volumes:
+      - ./downloader/conf:/conf
+      - ./downloader/log:/log
+      - ./downloader/run:/run
+      - ./downloader/data:/data
+    network_mode: "service:gluetun"
+
+  controller:
+    build: controller
+    network_mode: "service:gluetun"
+    volumes:
+      - ./controller/conf:/conf
+      - ./controller/logs:/logs
+      - ./controller/www:/var/www
+


### PR DESCRIPTION
This pull request allows a user to use a VPN whilst downloading from Tor within a container.

It uses the [gluetun](https://github.com/qdm12/gluetun) project to achieve this.

This sample configuration sets the controller and downloader to use the VPN connection and has necessary changes to allow the Web UI and RPC Ports to be accessed whilst the VPN is active.

This should help mitigate the risk and deanonymizing effect of downloading files from Tor. Especially when modifying the torrc file.