### PR TITLE
Install latest v2ray and add filtering of Tor nodes based on Speed

### DIFF
--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -11,10 +11,8 @@ RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libg
 && rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/install-release.sh \
 && cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
 && apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
-&& apk add --update --no-cache python3 py3-pip && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \
+&& apk add --update --no-cache python3 py3-stem && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \
 && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/guard_country_resolver.py
-
-RUN pip install stem 
 
 CMD ["/run/run_aria2.sh"]
 

--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -2,19 +2,19 @@ FROM alpine:latest
 
 LABEL maintainer="sn0b4ll"
 
-COPY 500retry.patch /home/
+COPY *.patch /home/
 
-COPY slowretry.patch /home/
+COPY --chmod=777 install-release.sh /home/
 
-COPY removeconnlimit.patch /home/
-
-COPY connclosed.patch /home/
-
-RUN apk add --update --no-cache bash tor tzdata vim v2ray autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev \
-&& git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch \
-&& rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch \
+RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip \
+&& /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch \
+&& rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/install-release.sh \
 && cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
-&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev
+&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
+&& apk add --update --no-cache python3 py3-pip && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \
+&& aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/guard_country_resolver.py
+
+RUN pip install stem 
 
 CMD ["/run/run_aria2.sh"]
 

--- a/downloader/install-release.sh
+++ b/downloader/install-release.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Identify architecture
+case "$(arch -s)" in
+    'i386' | 'i686')
+        MACHINE='32'
+        ;;
+    'amd64' | 'x86_64')
+        MACHINE='64'
+        ;;
+    'armv5tel')
+        MACHINE='arm32-v5'
+        ;;
+    'armv6l')
+        MACHINE='arm32-v6'
+        grep Features /proc/cpuinfo | grep -qw 'vfp' || MACHINE='arm32-v5'
+        ;;
+    'armv7' | 'armv7l')
+        MACHINE='arm32-v7a'
+        grep Features /proc/cpuinfo | grep -qw 'vfp' || MACHINE='arm32-v5'
+        ;;
+    'armv8' | 'aarch64')
+        MACHINE='arm64-v8a'
+        ;;
+    'mips')
+        MACHINE='mips32'
+        ;;
+    'mipsle')
+        MACHINE='mips32le'
+        ;;
+    'mips64')
+        MACHINE='mips64'
+        ;;
+    'mips64le')
+        MACHINE='mips64le'
+        ;;
+    'ppc64')
+        MACHINE='ppc64'
+        ;;
+    'ppc64le')
+        MACHINE='ppc64le'
+        ;;
+    'riscv64')
+        MACHINE='riscv64'
+        ;;
+    's390x')
+        MACHINE='s390x'
+        ;;
+    *)
+        echo "error: The architecture is not supported."
+        exit 1
+        ;;
+esac
+
+TMP_DIRECTORY="$(mktemp -d)/"
+ZIP_FILE="${TMP_DIRECTORY}v2ray-linux-$MACHINE.zip"
+DOWNLOAD_LINK="https://github.com/v2fly/v2ray-core/releases/latest/download/v2ray-linux-$MACHINE.zip"
+
+download_v2ray() {
+    curl -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE" "$DOWNLOAD_LINK" -#
+    if [ "$?" -ne '0' ]; then
+        echo 'error: Download failed! Please check your network or try again.'
+        exit 1
+    fi
+    curl -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE.dgst" "$DOWNLOAD_LINK.dgst" -#
+    if [ "$?" -ne '0' ]; then
+        echo 'error: Download failed! Please check your network or try again.'
+        exit 1
+    fi
+}
+
+verification_v2ray() {
+    for LISTSUM in 'md5' 'sha1' 'sha256' 'sha512'; do
+        SUM="$(${LISTSUM}sum $ZIP_FILE | sed 's/ .*//')"
+        CHECKSUM="$(grep $(echo $LISTSUM | tr [:lower:] [:upper:]) $ZIP_FILE.dgst | uniq | sed 's/.* //')"
+        if [ "$SUM" != "$CHECKSUM" ]; then
+            echo 'error: Check failed! Please check your network or try again.'
+            exit 1
+        fi
+    done
+}
+
+decompression() {
+    unzip -q "$ZIP_FILE" -d "$TMP_DIRECTORY"
+}
+
+install_v2ray() {
+    install -m 755 "${TMP_DIRECTORY}v2ray" "/usr/local/bin/v2ray"
+    install -d /usr/local/lib/v2ray/
+    install -m 755 "${TMP_DIRECTORY}geoip.dat" "/usr/local/lib/v2ray/geoip.dat"
+    install -m 755 "${TMP_DIRECTORY}geosite.dat" "/usr/local/lib/v2ray/geosite.dat"
+}
+
+information() {
+    echo 'installed: /usr/local/bin/v2ray'
+    echo 'installed: /usr/local/lib/v2ray/geoip.dat'
+    echo 'installed: /usr/local/lib/v2ray/geosite.dat'
+    rm -r "$TMP_DIRECTORY"
+    echo "removed: $TMP_DIRECTORY"
+    echo "You may need to execute a command to remove dependent software: apk del curl unzip"
+    echo "info: V2Ray is installed."
+}
+
+main() {
+    download_v2ray
+    decompression
+    install_v2ray
+    information
+}
+
+main

--- a/downloader/run/run_aria2.sh
+++ b/downloader/run/run_aria2.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -e
 
-python /home/creatorrc/creatorrc.py --speetor && mv -f tor_config.txt /conf/torrc
-
 touch /conf/aria2.session
 touch /log/aria2_log.txt
 
-tor --runasdaemon 1 -f /conf/torrc
+python /home/creatorrc/creatorrc.py --speetor && mv -f tor_config.txt /conf/torrc && tor --runasdaemon 1 -f /conf/torrc || tor --runasdaemon 1
 
 exec v2ray run -c /conf/config.json &
 exec aria2c --conf-path=/conf/aria2.conf --log=/log/aria2_log.txt --rpc-listen-port=${RPCPORT} --rpc-secret=${RPCSECRET}

--- a/downloader/run/run_aria2.sh
+++ b/downloader/run/run_aria2.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 set -e
 
+python /home/creatorrc/creatorrc.py --speetor && mv -f tor_config.txt /conf/torrc
+
 touch /conf/aria2.session
 touch /log/aria2_log.txt
 
-tor --runasdaemon 1
+tor --runasdaemon 1 -f /conf/torrc
 
 exec v2ray run -c /conf/config.json &
 exec aria2c --conf-path=/conf/aria2.conf --log=/log/aria2_log.txt --rpc-listen-port=${RPCPORT} --rpc-secret=${RPCSECRET}


### PR DESCRIPTION
This PR contains some general cleanup of the downloader dockerfile and includes a script to install the latest version of v2ray based off [here](https://github.com/v2fly/alpinelinux-install-v2ray/) as the version shipped by Alpine 3.18 is 5.3 instead of the latest 15.12.1 (With Alpine 3.19 this is no longer true)

Additionally it also uses [creatorrc](https://github.com/hephaest0s/creatorrc) to help speed up tor downloads by selecting the fastest 1000 relays as guards, the fastest 1000 exists as exit, and excludes the slowest 4000 relays so they don't become middle relays. 

~~PIP install needs a separated RUN entry or else it does not work due to needing to open a new terminal window. - Needed to prevent  "The folder you are executing pip from can no longer be found."~~