### PR TITLE
EXPERIMENTAL: Reduce Tor Circuits Created Client Side from 3 Hops to 2 Hops

### DIFF
--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -6,13 +6,14 @@ COPY *.patch /home/
 
 COPY --chmod=777 install-release.sh /home/
 
-RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip \
+RUN apk add --update --no-cache bash tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip libcap2 libcap-dev libevent libevent-dev libseccomp libseccomp-dev libssl3 openssl-dev>3 xz-dev zstd-libs \
 && /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch \
 && rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/install-release.sh \
-&& cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
-&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
+&& cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 && cd / && git clone https://gitlab.torproject.org/tpo/core/tor.git /home/tor && patch /home/tor/src/core/or/or.h < /home/routelen.patch && rm -f /home/routelen.patch \
+&& cd /home/tor && ./autogen.sh && ./configure --disable-asciidoc && make -j`nproc` && make install \
+&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip libcap-dev libevent-dev libseccomp-dev openssl-dev>3 xz-dev \
 && apk add --update --no-cache python3 py3-stem && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \
-&& aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/guard_country_resolver.py
+&& aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/guard_country_resolver.py && rm -rf /home/tor
 
 CMD ["/run/run_aria2.sh"]
 

--- a/downloader/routelen.patch
+++ b/downloader/routelen.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/or/or.h b/src/core/or/or.h
+index 088c45342b..265b84425a 100644
+--- a/src/core/or/or.h
++++ b/src/core/or/or.h
+@@ -899,7 +899,7 @@ typedef struct or_state_t or_state_t;
+ /********************************* circuitbuild.c **********************/
+ 
+ /** How many hops does a general-purpose circuit have by default? */
+-#define DEFAULT_ROUTE_LEN 3
++#define DEFAULT_ROUTE_LEN 2
+ 
+ /* Circuit Build Timeout "public" structures. */
+ 


### PR DESCRIPTION
DANGER: This commit compromises the security of Tor by completely eliminating the Middle Tor Nodes. It is not recommended to use this without a VPN or another form of anonymisation.

This commit modifies the source code of Tor to reduce the nodes used when creating the circuits from 3 to 2. Unfortunately attempting to reduce this to 1 did not work as most Tor nodes completely reject traffic using Single Node traffic.

Notably when applying the patch the download speed is more stable in comparison to using 3 nodes but please feel free to test this and give feedback before merging. 

Note .onion sites typically use a total of 6 hops - 3 client and 3 server. With this commit it reduces it to 5 hops due to 2 client and 3 server. 