### PR TITLE
Changes to allow for Onion Downloader to Appear More Like Tor Browser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - RPCPORT=6800
       - RPCSECRET=TEST123
       - TORSERVNUM=50
+      - GETTORUA=true
     volumes:
       - ./downloader/conf:/conf
       - ./downloader/log:/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
 
   downloader:
     build: downloader
+    depends_on:
+      gluetun:
+        condition: service_healthy
     environment:
       - RPCPORT=6800
       - RPCSECRET=TEST123

--- a/docker-compose_no_vpn.yml
+++ b/docker-compose_no_vpn.yml
@@ -5,6 +5,7 @@ services:
       - RPCPORT=6800
       - RPCSECRET=TEST123
       - TORSERVNUM=50
+      - GETTORUA=true
     volumes:
       - ./downloader/conf:/conf
       - ./downloader/log:/log

--- a/downloader/conf/aria2.conf
+++ b/downloader/conf/aria2.conf
@@ -27,3 +27,4 @@ rpc-listen-all=true
 rpc-allow-origin-all=true
 
 disable-ipv6=true
+user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0

--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -7,8 +7,8 @@ COPY *.patch /home/
 COPY --chmod=777 install-release.sh /home/
 
 RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip \
-&& /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch \
-&& rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/install-release.sh \
+&& /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch && patch /home/aria2/src/HttpRequest.cc < /home/useragentsort.patch \
+&& rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/useragentsort.patch && rm -f /home/install-release.sh \
 && cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
 && apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
 && apk add --update --no-cache python3 py3-stem && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \

--- a/downloader/run/get_tor_ua.py
+++ b/downloader/run/get_tor_ua.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""\
+Heavily modified based on the original script by @mai-gh
+https://github.com/mai-gh/get_tor_ua
+
+This script fetches the default branch of the Tor Browser GitLab repository,
+retrieves the latest milestone version, and constructs a User-Agent string
+based on the values found in the repository. It then updates aria2.conf with the new User-Agent string.
+"""
+import urllib.request
+import json
+import re
+import sys
+
+hdrs = {
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0',
+  'Accept-Encoding': 'gzip, deflate, br'
+}
+
+url_base = 'https://gitlab.torproject.org/tpo/applications/tor-browser'
+project_path_encoded = urllib.parse.quote_plus('tpo/applications/tor-browser')
+api_url = f'https://gitlab.torproject.org/api/v4/projects/{project_path_encoded}'
+
+branch = None
+
+try:
+    with urllib.request.urlopen(urllib.request.Request(method='GET', url=api_url, headers=hdrs)) as response:
+        if response.status == 200:
+            project_data = json.load(response)
+            branch = project_data.get('default_branch')
+            if not branch:
+                print("Error: Could not find 'default_branch' in API response.")
+                sys.exit(1)
+        else:
+            print(f"Error: API request failed with status {response.status}")
+            print(response.read().decode())
+            sys.exit(1)
+
+except urllib.error.URLError as e:
+    print(f"Error: Could not connect to GitLab API: {e}")
+    sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f"Error: Could not decode JSON response from API: {e}")
+    sys.exit(1)
+except KeyError:
+    print("Error: 'default_branch' key not found in the API response.")
+    sys.exit(1)
+
+print(f"Successfully fetched default branch: {branch}")
+
+# this logic comes from ./build/moz.configure/init.configure
+try:
+    milestone_url = url_base + '/-/raw/' + branch + '/config/milestone.txt'
+    with urllib.request.urlopen(urllib.request.Request(method='GET', url=milestone_url, headers=hdrs)) as response:
+      milestone_lines = [l.decode().strip() for l in response.readlines()]
+      last_milestone_line = next((line for line in reversed(milestone_lines) if line), None)
+
+      if last_milestone_line:
+          spoofed_version = last_milestone_line.split(".")[0]
+          if not spoofed_version.isdigit():
+              print(f"Warning: Extracted spoofed_version '{spoofed_version}' is not purely numeric.")
+      else:
+          print("Error: Could not find a valid version line in milestone.txt.")
+          sys.exit(1)
+
+    rfph_url = url_base + '/-/raw/' + branch + '/toolkit/components/resistfingerprinting/nsRFPService.h'
+    with urllib.request.urlopen(urllib.request.Request(method='GET', url=rfph_url, headers=hdrs)) as response:
+      rfph_raw = response.read().decode()
+      spoofed_ua_os_lines = [ l for l in rfph_raw.splitlines() if '#  define SPOOFED_UA_OS' in l]
+      gecko_trail_lines = [ l for l in rfph_raw.splitlines() if '#define LEGACY_UA_GECKO_TRAIL' in l]
+
+      if not spoofed_ua_os_lines:
+          print("Error: Could not find '#  define SPOOFED_UA_OS' in nsRFPService.h")
+          sys.exit(1)
+      if not gecko_trail_lines:
+          print("Error: Could not find '#define LEGACY_UA_GECKO_TRAIL' in nsRFPService.h")
+          sys.exit(1)
+
+      try:
+          spoofed_ua_os = spoofed_ua_os_lines[0].split('"')[1]
+          gecko_trail = gecko_trail_lines[0].split('"')[1]
+      except IndexError:
+           print("Error: Could not parse SPOOFED_UA_OS or LEGACY_UA_GECKO_TRAIL from nsRFPService.h")
+           sys.exit(1)
+
+except urllib.error.URLError as e:
+    print(f"Error: Could not fetch remote files (milestone.txt or nsRFPService.h): {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"An unexpected error occurred while processing remote files: {e}")
+    sys.exit(1)
+
+# Example: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0
+try:
+    user_agent_string = "Mozilla/5.0 (%s; rv:%d.0) Gecko/%d Firefox/%d.0" % (spoofed_ua_os, int(spoofed_version), int(gecko_trail), int(spoofed_version))
+    print(f"Constructed User-Agent: {user_agent_string}")
+except ValueError as e:
+    print(f"Error: Could not format User-Agent string: {e}")
+    sys.exit(1)
+except IndexError as e:
+    print(f"Error constructing user agent string. Check fetched values. {e}")
+    sys.exit(1)
+
+conf_file_path = "/conf/aria2.conf"
+conf_content = ""
+
+try:
+    with open(conf_file_path, "r") as file:
+        conf_content = file.read()
+except FileNotFoundError:
+    print(f"Error: Configuration file '{conf_file_path}' not found.")
+    sys.exit(1)
+except IOError as e:
+    print(f"Error: Could not read configuration file '{conf_file_path}': {e}")
+    sys.exit(1)
+
+target_ua_line_content = f'user-agent={user_agent_string}'
+regex_pattern = r"user-agent=.*"
+
+existing_ua_match = re.search(regex_pattern, conf_content)
+
+if existing_ua_match:
+    existing_ua_line = existing_ua_match.group(0).strip()
+    if existing_ua_line == target_ua_line_content:
+        print(f"User-Agent in '{conf_file_path}' already matches '{user_agent_string}'. No changes needed.")
+        sys.exit(0)
+    else:
+        print(f"Existing User-Agent '{existing_ua_line}' found, but needs updating.")
+else:
+    print("No existing User-Agent line found in the configuration file.")
+
+updated_conf_content, num_subs = re.subn(regex_pattern, target_ua_line_content, conf_content, count=1)
+
+if num_subs > 0:
+    print(f"Replaced User-Agent in {conf_file_path}: {user_agent_string}")
+else:
+    if conf_content:
+        if not conf_content.endswith("\n"):
+            updated_conf_content = conf_content + "\n" + target_ua_line_content
+            print(f"Added User-Agent to {conf_file_path}: {user_agent_string}")
+        else:
+            updated_conf_content = conf_content + target_ua_line_content
+            print(f"Added User-Agent to {conf_file_path}: {user_agent_string}")
+    else:
+        print(f"File is empty or does not exist! Please check the file path: {conf_file_path}")
+
+if updated_conf_content and not updated_conf_content.endswith("\n"):
+    updated_conf_content += "\n"
+elif not updated_conf_content and target_ua_line_content:
+     pass
+
+try:
+    with open(conf_file_path, "w") as file:
+        file.write(updated_conf_content)
+except IOError as e:
+    print(f"Error: Could not write to configuration file '{conf_file_path}': {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"Unexpected error: {e}")
+    sys.exit(1)
+
+print(f"Changes Written Successfully to {conf_file_path}")
+sys.exit(0)

--- a/downloader/useragentsort.patch
+++ b/downloader/useragentsort.patch
@@ -1,0 +1,100 @@
+diff --git a/src/HttpRequest.cc b/src/HttpRequest.cc
+index b5fb4f86..1e2d0ecf 100644
+--- a/src/HttpRequest.cc
++++ b/src/HttpRequest.cc
+@@ -141,6 +141,23 @@ std::string getHostText(const std::string& host, uint16_t port)
+ }
+ } // namespace
+ 
++const static std::vector<std::string> headersSort = {
++  "Host:",
++  "User-Agent:",
++  "Accept:",
++  "Accept-Encoding:",
++  "Referer:",
++  "Connection:",
++  "Cookie:",
++  "Range:",
++  "Authorization:",
++  "Proxy-Authorization:",
++  "Pragma:",
++  "Cache-Control:",
++  "If-Modified-Since:",
++  "Want-Digest:",
++};
++
+ std::string HttpRequest::createRequest()
+ {
+   authConfig_ = authConfigFactory_->createAuthConfig(request_, option_);
+@@ -265,20 +282,46 @@ std::string HttpRequest::createRequest()
+       builtinHds.emplace_back("Want-Digest:", wantDigest);
+     }
+   }
+-  for (const auto& builtinHd : builtinHds) {
+-    auto it = std::find_if(std::begin(headers_), std::end(headers_),
+-                           [&builtinHd](const std::string& hd) {
+-                             return util::istartsWith(hd, builtinHd.first);
+-                           });
+-    if (it == std::end(headers_)) {
+-      requestLine += builtinHd.first;
+-      requestLine += ' ';
+-      requestLine += builtinHd.second;
++  // std::vector<std::string> headersSortCopy(headersSort.begin(), headersSort.end());
++  // for (const auto& hd : builtinHds) {
++  //   builtinHdsMap[hd.first] = hd;
++  //   if (std::find(std::begin(headersSort), std::end(headersSort), hd.first) ==
++  //       std::end(headersSort)) {
++  //     headersSortCopy.push_back(hd.first);
++  //   }
++  // }
++  std::map<std::string, std::pair<std::string, std::string>> builtinHdsMap;
++  for (const auto& hd : builtinHds) {
++    builtinHdsMap[hd.first] = hd;
++  }
++  std::set<std::string> skipHeaders;
++  for (const auto& k : headersSort) {
++    auto it = std::find_if(
++      std::begin(headers_),
++      std::end(headers_),
++      [&k](const std::string& hd) {
++        return util::istartsWith(hd, k);
++      }
++    );
++    if (it != std::end(headers_)) {
++      skipHeaders.insert(*it);
++      requestLine += *it;
+       requestLine += "\r\n";
++    } else {
++      auto builtinHdIt = builtinHdsMap.find(k);
++      if (builtinHdIt != std::end(builtinHdsMap)) {
++        requestLine += builtinHdIt->second.first;
++        requestLine += ' ';
++        requestLine += builtinHdIt->second.second;
++        requestLine += "\r\n";
++      }
+     }
+   }
+   // append additional headers given by user.
+   for (const auto& hd : headers_) {
++    if (skipHeaders.find(hd) != std::end(skipHeaders)) {
++      continue;
++    }
+     requestLine += hd;
+     requestLine += "\r\n";
+   }
+@@ -294,12 +337,12 @@ std::string HttpRequest::createProxyRequest() const
+   requestLine += getURIHost();
+   requestLine += ':';
+   requestLine += util::uitos(getPort());
+-  requestLine += " HTTP/1.1\r\nUser-Agent: ";
+-  requestLine += userAgent_;
+-  requestLine += "\r\nHost: ";
++  requestLine += " HTTP/1.1\r\nHost: ";
+   requestLine += getURIHost();
+   requestLine += ':';
+   requestLine += util::uitos(getPort());
++  requestLine += "\r\nUser-Agent: ";
++  requestLine += userAgent_;
+   requestLine += "\r\n";
+ 
+   if (!proxyRequest_->getUsername().empty()) {


### PR DESCRIPTION
This Pull Request introduces the initial set of features to make aria2-onion-downloader appear more like the Tor Browser. During testing I found if we use the default Aria2 user agent certain onion sites were throttling the download speeds or preventing downloads outright. This pull request has several features to achieve this.

1. It sets the user agent to the current Tor Browser in the config file by default
2. It introduces the following patch from https://github.com/zeromake/aria2-zero/commit/fd11a873c18daf368cd245607c10e6465f405700 which allows for browser headers to display more like Firefox. Before the patch Aria2 put the User-Agent Header first before Host when real browsers attach Host first.
3. Disables the Want-Digest header as this is used by certain sites to fingerprint Aria2 use and no real browser seems to use it
4. Changes the Accept header to align more with the Tor Browser. No browsers appear to advertise Metalink as an example. 
5. Created a new script heavily modified but based on [here](https://github.com/mai-gh/get_tor_ua) which allows us to get the latest version of the user agent from the gitlab repo and write this directly to the config file. An environment variable GETTORUA=true has been set to allow for it to be disabled if people want their own custom user agents to stay.

Below is an example of the changes that have happened before and after. This should improve compatibility with some sites such as ones hosted on places such as cloudflare.

<img width="1643" alt="BrowserHeaders" src="https://github.com/user-attachments/assets/9dfe22a1-1035-4d29-9d89-fa2d91223317" />

