### PR TITLE
More Aria2 Patches

### DIFF
--- a/downloader/cdfix.patch
+++ b/downloader/cdfix.patch
@@ -1,0 +1,32 @@
+diff --git a/src/util.cc b/src/util.cc
+index 07502c0e..915e3091 100644
+--- a/src/util.cc
++++ b/src/util.cc
+@@ -1555,6 +1555,9 @@ ssize_t parse_content_disposition(char* dest, size_t destlen,
+   case CD_AFTER_VALUE:
+   case CD_TOKEN:
+     return destlen - dlen;
++  case CD_BEFORE_DISPOSITION_PARM_NAME:
++    if (dlen == destlen) return -1;
++    return destlen - dlen;  
+   case CD_VALUE_CHARS:
+     if (charset == CD_ENC_UTF8 && dfa_state != UTF8_ACCEPT) {
+       return -1;
+@@ -1572,9 +1575,16 @@ std::string getContentDispositionFilename(const std::string& header,
+   size_t cdvallen = cdval.size();
+   const char* charset;
+   size_t charsetlen;
++  std::string _header = header;
++
++  // add attachment start
++  if (!startsWith(_header, "attachment")) {
++    _header = "attachment; " + _header;
++  }
++
+   ssize_t rv =
+       parse_content_disposition(cdval.data(), cdvallen, &charset, &charsetlen,
+-                                header.c_str(), header.size(), defaultUTF8);
++                                _header.c_str(), _header.size(), defaultUTF8);
+   if (rv == -1) {
+     return "";
+   }

--- a/downloader/deflateraw.patch
+++ b/downloader/deflateraw.patch
@@ -1,0 +1,35 @@
+diff --git a/src/GZipDecodingStreamFilter.cc b/src/GZipDecodingStreamFilter.cc
+index d24acc3e..07b8a0af 100644
+--- a/src/GZipDecodingStreamFilter.cc
++++ b/src/GZipDecodingStreamFilter.cc
+@@ -48,6 +48,7 @@ GZipDecodingStreamFilter::GZipDecodingStreamFilter(
+     : StreamFilter{std::move(delegate)},
+       strm_{nullptr},
+       finished_{false},
++      rawMode_{false},
+       bytesProcessed_{0}
+ {
+ }
+@@ -66,7 +67,8 @@ void GZipDecodingStreamFilter::init()
+   strm_->next_in = Z_NULL;
+ 
+   // initialize z_stream with gzip/zlib format auto detection enabled.
+-  if (Z_OK != inflateInit2(strm_, 47)) {
++  // negative windowBits enables raw mode support.
++  if (Z_OK != inflateInit2(strm_, rawMode_ ? -15 : 47)) {
+     throw DL_ABORT_EX("Initializing z_stream failed.");
+   }
+ }
+@@ -105,6 +107,12 @@ GZipDecodingStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
+       finished_ = true;
+     }
+     else if (ret != Z_OK && ret != Z_BUF_ERROR) {
++      if (!rawMode_) {
++        // reset in raw mode
++        rawMode_ = true;
++        init();
++        return transform(out, segment, inbuf, inlen);
++      }
+       throw DL_ABORT_EX(fmt("libz::inflate() failed. cause:%s", strm_->msg));
+     }
+ 

--- a/downloader/deflateraw2.patch
+++ b/downloader/deflateraw2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/GZipDecodingStreamFilter.h b/src/GZipDecodingStreamFilter.h
+index d9c3c22e..084ca8ef 100644
+--- a/src/GZipDecodingStreamFilter.h
++++ b/src/GZipDecodingStreamFilter.h
+@@ -49,6 +49,8 @@ private:
+ 
+   bool finished_;
+ 
++  bool rawMode_;
++  
+   size_t bytesProcessed_;
+ 
+   static const size_t OUTBUF_LENGTH = 16_k;

--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -7,8 +7,9 @@ COPY *.patch /home/
 COPY --chmod=777 install-release.sh /home/
 
 RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip \
-&& /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch && patch /home/aria2/src/HttpRequest.cc < /home/useragentsort.patch \
-&& rm -f /home/500retry.patch && rm -f /home/slowretry.patch && rm -f /home/removeconnlimit.patch && rm -f /home/connclosed.patch && rm -f /home/useragentsort.patch && rm -f /home/install-release.sh \
+&& /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch \ 
+&& patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch && patch /home/aria2/src/HttpRequest.cc < /home/useragentsort.patch && patch /home/aria2/src/GZipDecodingStreamFilter.cc < /home/deflateraw.patch && patch /home/aria2/src/GZipDecodingStreamFilter.h < /home/deflateraw2.patch && patch /home/aria2/src/HttpServerBodyCommand.cc < /home/highcpurpc.patch && patch /home/aria2/src/HttpHeaderProcessor.cc < /home/emptyheadervalue.patch && patch /home/aria2/src/util.cc < /home/cdfix.patch \
+&& rm -f /home/*.patch && rm -f /home/install-release.sh \
 && cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
 && apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
 && apk add --update --no-cache python3 py3-stem && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \

--- a/downloader/emptyheadervalue.patch
+++ b/downloader/emptyheadervalue.patch
@@ -1,0 +1,22 @@
+diff --git a/src/HttpHeaderProcessor.cc b/src/HttpHeaderProcessor.cc
+index 53f061e6..91c4d7c4 100644
+--- a/src/HttpHeaderProcessor.cc
++++ b/src/HttpHeaderProcessor.cc
+@@ -43,6 +43,7 @@
+ #include "DlAbortEx.h"
+ #include "A2STR.h"
+ #include "error_code.h"
++#include "LogFactory.h"
+ 
+ namespace aria2 {
+ 
+@@ -362,7 +363,8 @@ bool HttpHeaderProcessor::parse(const unsigned char* data, size_t length)
+ 
+     case FIELD_NAME:
+       if (util::isLws(c) || util::isCRLF(c)) {
+-        throw DL_ABORT_EX("Bad HTTP header: missing ':'");
++        A2_LOG_WARN("Bad HTTP header: missing ':'");
++        break;
+       }
+ 
+       if (c == ':') {

--- a/downloader/highcpurpc.patch
+++ b/downloader/highcpurpc.patch
@@ -1,0 +1,12 @@
+diff --git a/src/HttpServerBodyCommand.cc b/src/HttpServerBodyCommand.cc
+index e9e7b92a..1ef48f7f 100644
+--- a/src/HttpServerBodyCommand.cc
++++ b/src/HttpServerBodyCommand.cc
+@@ -149,6 +149,7 @@ void HttpServerBodyCommand::addHttpServerResponseCommand(bool delayed)
+   auto resp = make_unique<HttpServerResponseCommand>(getCuid(), httpServer_, e_,
+                                                      socket_);
+   if (delayed) {
++    e_->deleteSocketForWriteCheck(socket_, resp.get());
+     e_->addCommand(
+         make_unique<DelayedCommand>(getCuid(), e_, 1_s, std::move(resp), true));
+     return;

--- a/downloader/run/run_aria2.sh
+++ b/downloader/run/run_aria2.sh
@@ -100,8 +100,7 @@ echo "V2Ray config generated at /conf/config.json"
 
 if [ "$GETTORUA" = "true" ]; then
 echo "Getting latest Tor Browser User-Agent..."
-python /run/get_tor_ua.py >> /log/get_tor_ua.log 2>&1
-if [ $? -ne 0 ]; then
+if ! python /run/get_tor_ua.py >> /log/get_tor_ua.log 2>&1; then
     echo "Warning: get_tor_ua.py script exited with an error. Check /log/get_tor_ua.log"
   fi
 fi


### PR DESCRIPTION
These patches allow for more files to be downloaded successfully when sites are not following proper standards.

The following fixes have been added: 
https://github.com/aria2/aria2/pull/2268 - deflate raw mode support - Test URL https://comment.bilibili.com/771495675.xml - Download Fails without Patch
https://github.com/aria2/aria2/pull/2209 - Fixes RPC high CPU usage with unauthorised responses
https://github.com/aria2/aria2/pull/1712 - Allows sites with missing values in headers after : to work 
https://github.com/zeromake/aria2-zero/commit/a89b88f88d6fd197f7f2c6b046d8a00f845942e8 - Fixes Content-Disposition Issues such as trailing ; on end of file link - Test URL http://test.greenbytes.de/tech/tc2231/attwithasciifilenamenqs.asis - File Name will show correctly when this patch is applied.


