### PR TITLE
Fix: Secure file permissions and add Tor health-check

### DIFF
--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="sn0b4ll"
 
 COPY *.patch /home/
 
-COPY --chmod=777 install-release.sh /home/
+COPY --chmod=755 install-release.sh /home/
 
 RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libgcc gmp libtool gnutls gnutls-dev nettle libssh2 libssh2-dev ca-certificates c-ares c-ares-dev libxml2 libxml2-dev sqlite-libs sqlite-dev automake cppunit cppunit-dev util-macros gettext gettext-dev zlib zlib-dev curl unzip \
 && /home/install-release.sh && git clone https://github.com/aria2/aria2.git /home/aria2 && patch /home/aria2/src/HttpSkipResponseCommand.cc < /home/500retry.patch && patch /home/aria2/src/DownloadCommand.cc < /home/slowretry.patch && patch /home/aria2/src/OptionHandlerFactory.cc < /home/removeconnlimit.patch \ 

--- a/downloader/dockerfile
+++ b/downloader/dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --no-cache bash tor tzdata vim autoconf build-base git libg
 && patch /home/aria2/src/SocketBuffer.cc < /home/connclosed.patch && patch /home/aria2/src/HttpRequest.cc < /home/useragentsort.patch && patch /home/aria2/src/GZipDecodingStreamFilter.cc < /home/deflateraw.patch && patch /home/aria2/src/GZipDecodingStreamFilter.h < /home/deflateraw2.patch && patch /home/aria2/src/HttpServerBodyCommand.cc < /home/highcpurpc.patch && patch /home/aria2/src/HttpHeaderProcessor.cc < /home/emptyheadervalue.patch && patch /home/aria2/src/util.cc < /home/cdfix.patch \
 && rm -f /home/*.patch && rm -f /home/install-release.sh \
 && cd /home/aria2 && autoreconf -i && ./configure && make -j`nproc` && make install && rm -rf /home/aria2 \
-&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev curl unzip \
+&& apk del autoconf build-base git libtool gnutls-dev libssh2-dev c-ares-dev libxml2-dev sqlite-dev automake cppunit-dev util-macros gettext-dev zlib-dev unzip \
 && apk add --update --no-cache python3 py3-stem && cd /home && mkdir creatorrc && cd /home/creatorrc && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/creatorrc.py \
 && aria2c https://raw.githubusercontent.com/hephaest0s/creatorrc/master/guard_country_resolver.py
 

--- a/downloader/run/run_aria2.sh
+++ b/downloader/run/run_aria2.sh
@@ -119,6 +119,12 @@ ARIA2_ARGS=(
   --async-dns=false
 )
 
+echo "Waiting for Tor to bootstrap on port 9050..."
+while ! curl --socks5-hostname 127.0.0.1:9050 -s https://check.torproject.org/api/ip > /dev/null; do
+  sleep 2
+done
+echo "Tor is ready! Starting aria2..."
+
 # If there are any .txt files in /conf, use aria2c -i to read URLs.
 # If multiple .txt files exist, concatenate them into a single temp input file.
 shopt -s nullglob

--- a/downloader/run/run_aria2.sh
+++ b/downloader/run/run_aria2.sh
@@ -120,7 +120,7 @@ ARIA2_ARGS=(
 )
 
 echo "Waiting for Tor to bootstrap on port 9050..."
-while ! curl --socks5-hostname 127.0.0.1:9050 -s https://check.torproject.org/api/ip > /dev/null; do
+while ! curl --socks5-hostname 127.0.0.1:9050 -s -m 5 https://check.torproject.org/api/ip > /dev/null 2>&1; do
   sleep 2
 done
 echo "Tor is ready! Starting aria2..."


### PR DESCRIPTION
* **Security**: Changed `install-release.sh` permissions from `777` to `755` in `downloader/dockerfile`.
* **Stability**: Added a `curl` health-check loop in `run_aria2.sh` to wait for Tor's proxy bootstrapping before starting `aria2c`.